### PR TITLE
Corrige a atualização da lista de hábitos ao editar um hábito

### DIFF
--- a/lib/views/home/habit_tracking_screen.dart
+++ b/lib/views/home/habit_tracking_screen.dart
@@ -312,7 +312,9 @@ class _HabitTrackingScreenState extends State<HabitTrackingScreen> {
                                   ],
                                 );
                               },
-                            );
+                            ).then((value) {
+                              fetchHabitsFromFirestore();
+                            });
                           },
                           child: Container(
                             margin: const EdgeInsets.only(bottom: 10),


### PR DESCRIPTION
Adiciona um callback (`fetchHabitsFromFirestore`) no retorno do widget de diálogo para atualizar a lista de hábitos. O `then` associa uma função para ser executada quando a `Future` alvo completar. Fecha #107.